### PR TITLE
 Make Gradio demo compatible with loghi-htr 2.1.x

### DIFF
--- a/gradio/docker/docker-compose.yml
+++ b/gradio/docker/docker-compose.yml
@@ -63,7 +63,7 @@ services:
   htr:
     user: ${MY_UID}:${MY_GID}
     image: 'loghi/docker.htr'
-    command: sh -c 'cd api && gunicorn --workers=1 --threads=1 -b :5000 "app:create_app()"'
+    command: sh -c 'cd api && uvicorn app:app --host 0.0.0.0 --port 5000'
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
With the [recent changes to Loghi HTR](https://github.com/knaw-huc/loghi-htr/commit/d0e9a87db653c5a674d4523e30c588f7fec98b73) to use ASGI instead of WSGI, the Gradio demo set up through docker stopped working. The docker-compose file tried to call on gunicorn, which was removed as a requirement to Loghi HTR and replaced by uvicorn. 

This PR replaces the command call to gunicorn by a call to uvicorn, following the changes to the `start_local_app.py` script in the [Loghi HTR API](https://github.com/knaw-huc/loghi-htr/blob/67750f3d2647068670963322d950b0c3fa12927a/src/api/start_local_app.sh).